### PR TITLE
Move SPA fallback route

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,9 +35,6 @@ app.use((req, res, next) => {
 });
 
 app.use(express.static(path.join(__dirname, '../frontend/dist')));
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
-});
 
 // Routes
 app.use('/api/', indexRoutes);
@@ -45,6 +42,10 @@ app.use('/api/auth', authRoutes);
 app.use('/api/cards', cardRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/users', userRoutes);
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '../frontend/dist/index.html'));
+});
 
 // Gestion centralisée des erreurs
 app.use(errorHandler);


### PR DESCRIPTION
## Summary
- ensure API routes are registered before the SPA catch-all

## Testing
- `npm run build --silent` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6883d497f9188321b9fcc6b0cc3b4664